### PR TITLE
Hide P2 board until P2 has placed all ships

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,8 @@ class App extends React.Component {
                       { this.props.state.squares.activeP2 ? null : <Instructions />}
                     </div>
                     <div className={ shipCounter === 5 ? 'start-btn-container': 'start-btn-container-closed' }>
-                      <StartModal props={squares} />
+                      {/* <StartModal props={squares} /> */}
+                      { this.props.state.squares.activeP2 ? null : <StartModal props={squares} />}
                     </div>
                   </div>
                 </div>

--- a/src/App.js
+++ b/src/App.js
@@ -35,8 +35,9 @@ class App extends React.Component {
   }
 
   render () {
+    console.log('APP PROPS', this.props)
     const { squares } = this.props.state
-    const placedShips = this.props.state.squares.activeBtn
+    const placedShips = squares.activeBtn
     let shipCounter = 0
     for (let i = 0; i<= placedShips.length; i++) {
       if (placedShips[i] === false) {
@@ -59,10 +60,11 @@ class App extends React.Component {
                   </div>
                 <div className='game'>
                   <div className='game-board'>
-                    <Board  />
+                    <Board />
                   </div>
                   <div className='second-board'>
-                      <Board2 props={ this.props.state } />
+                    {/* <Board2 props={ this.props.state } /> */}
+                    { this.props.state.squares.activeP2 ? <Board2 props={ this.props.state }/> : null}
                   </div>
                   <div className='instructions-container'>
                     <div className="instructions">

--- a/src/App.js
+++ b/src/App.js
@@ -68,7 +68,8 @@ class App extends React.Component {
                   </div>
                   <div className='instructions-container'>
                     <div className="instructions">
-                      <Instructions />
+                      {/* <Instructions /> */}
+                      { this.props.state.squares.activeP2 ? null : <Instructions />}
                     </div>
                     <div className={ shipCounter === 5 ? 'start-btn-container': 'start-btn-container-closed' }>
                       <StartModal props={squares} />


### PR DESCRIPTION
- P1 does not see P2 board until P2 has placed all their ships
- Once `this.props.state.squares.activeP2` is toggled from `false` to `true` will P1 see the board
- Should the link be hidden after P2 is connected? Currently coded as hidden.
- Needs a bit of styling help @suepark09 lol